### PR TITLE
Fix error with swagger-codegen v2.1.6

### DIFF
--- a/src/main/java/com/decision/swagger/codegen/typescript/angular2/TypescriptAngular2Generator.java
+++ b/src/main/java/com/decision/swagger/codegen/typescript/angular2/TypescriptAngular2Generator.java
@@ -23,6 +23,14 @@ public class TypescriptAngular2Generator extends TypeScriptAngularClientCodegen 
         return "Generates a TypeScript Angular2 client library.";
     }
 
+    @Override
+    public void processOpts() {
+        super.processOpts();
+        supportingFiles.clear();
+        supportingFiles.add(new SupportingFile("model.d.mustache", modelPackage().replace('.', File.separatorChar), "model.d.ts"));
+    }
+
+
     public TypescriptAngular2Generator() {
         super();
         this.outputFolder = "generated-code/typescript-angular2";
@@ -30,8 +38,6 @@ public class TypescriptAngular2Generator extends TypeScriptAngularClientCodegen 
         embeddedTemplateDir = templateDir = "typescript-angular2";
         apiPackage = "api";
         modelPackage = "model";
-        supportingFiles.remove(supportingFiles.get(supportingFiles.size() - 1));
-        supportingFiles.add(new SupportingFile("model.d.mustache", modelPackage().replace('.', File.separatorChar), "model.d.ts"));
     }
 
     @Override


### PR DESCRIPTION
```
Exception in thread "main" java.util.ServiceConfigurationError: io.swagger.codegen.CodegenConfig: Provider com.decision.swagger.codegen.typescript.angular2.TypescriptAngular2Generator could not be instantiated
        at java.util.ServiceLoader.fail(ServiceLoader.java:224)
        at java.util.ServiceLoader.access$100(ServiceLoader.java:181)
        at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:377)
        at java.util.ServiceLoader$1.next(ServiceLoader.java:445)
        at ch.lambdaj.function.convert.ConverterIterator.next(ConverterIterator.java:37)
        at ch.lambdaj.Lambda.convert(Lambda.java:986)
        at ch.lambdaj.Lambda.extract(Lambda.java:1035)
        at ch.lambdaj.collection.LambdaIterable.doExtract(LambdaIterable.java:155)
        at ch.lambdaj.collection.LambdaIterable.extract(LambdaIterable.java:151)
        at io.swagger.codegen.cmd.Langs.run(Langs.java:20)
        at io.swagger.codegen.SwaggerCodegen.main(SwaggerCodegen.java:36)
Caused by: java.lang.ArrayIndexOutOfBoundsException: -1
        at java.util.ArrayList.elementData(ArrayList.java:400)
        at java.util.ArrayList.get(ArrayList.java:413)
        at com.decision.swagger.codegen.typescript.angular2.TypescriptAngular2Generator.<init>(TypescriptAngular2Generator.java:33)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
        at java.lang.Class.newInstance(Class.java:383)
        at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:373)
        ... 8 more
```